### PR TITLE
Feature: Allow Fetch options on sprite sheet Request

### DIFF
--- a/src/icon-sprite-loader.js
+++ b/src/icon-sprite-loader.js
@@ -13,7 +13,7 @@ const { localStorage, ICON_SPRITE_ID } = window
  * ⚠️ Note that this process assumes fetch is available, so be sure to polyfill it
  * with whatwg-fetch if you support older browsers!
  */
-function iconSpriteLoader(customSpriteId) {
+function iconSpriteLoader({customSpriteId, fetchOptions}) {
   const spriteId = customSpriteId || ICON_SPRITE_ID
 
   if (
@@ -27,7 +27,7 @@ function iconSpriteLoader(customSpriteId) {
       localStorage.getItem('SVG_SPRITE_DATA')
     )
   } else {
-    fetch(spriteId)
+    fetch(spriteId, fetchOptions)
       .then(res => {
         if (!res.ok) throw new Error(res.statusText)
         return res

--- a/src/icon-sprite-loader.js
+++ b/src/icon-sprite-loader.js
@@ -13,7 +13,7 @@ const { localStorage, ICON_SPRITE_ID } = window
  * ⚠️ Note that this process assumes fetch is available, so be sure to polyfill it
  * with whatwg-fetch if you support older browsers!
  */
-function iconSpriteLoader({customSpriteId, fetchOptions}) {
+function iconSpriteLoader({ customSpriteId, fetchOptions }) {
   const spriteId = customSpriteId || ICON_SPRITE_ID
 
   if (


### PR DESCRIPTION
Allows the user to pass options to the fetch for the sprite sheet.

BREAKING CHANGE:
`iconSpriteLoader` now accepts a single parameter that is an object of options. The parameter
customSpriteId has been moved into the options parameter.

Alternatively, if we do not want to implement a breaking change for this fix, I could validate the arguments and test to see if the first argument is an object or a string and use accordingly.

